### PR TITLE
Update project_export.sh

### DIFF
--- a/reference-architecture/day2ops/scripts/project_export.sh
+++ b/reference-architecture/day2ops/scripts/project_export.sh
@@ -206,7 +206,7 @@ svcs(){
             .metadata.generation,
             .spec.clusterIP
             )' > ${PROJECT}/svc_${svc}.json
-    if [[ $(cat ${PROJECT}/svc_${svc}.json | jq -e '.spec.selector.app') == "null" ]]; then
+    if [[ $(cat ${PROJECT}/svc_${svc}.json | jq -e '.spec.selector') != "null" ]]; then
       oc get --export -o json endpoints ${svc} -n ${PROJECT}| jq '
         del(.status,
             .metadata.uid,


### PR DESCRIPTION
export endpoints only if the SVC has defined .spec.selector fields.
Prevents failure on SVC objects that only contain a spec.externalName field but no selectors.
Test case json:

```
{
  "apiVersion": "v1",
  "kind": "Service",
  "metadata": {
    "name": "test-svc"
  },
  "spec": {
    "externalName": "test-svc.domain.tld",
    "sessionAffinity": "None",
    "type": "ExternalName"
  }
}
```